### PR TITLE
Add Dockerised Gradio app with model control endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/f5audio/f5-tts:latest
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir gradio fastapi uvicorn
+
+EXPOSE 7860
+CMD ["python", "-m", "custom-gradio-f5-tts"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# custom-gradio-f5-tts
+# Custom Gradio F5-TTS
+
+This project provides a Dockerised Gradio application for the F5-TTS voice
+cloning model.  It extends the standard Gradio server with additional API
+endpoints to control model loading and unloading and to generate multiple
+clips from a single reference voice.
+
+## Features
+
+- `/load` – load the F5-TTS model into VRAM.
+- `/unload` – remove the model from VRAM while keeping cache files on disk.
+- `/several` – supply a reference voice and newline separated phrases to
+  generate several WAV files in one request.
+
+## Running locally
+
+```bash
+python -m custom-gradio-f5-tts
+```
+
+## Docker
+
+```bash
+docker build -t custom-f5-tts .
+docker run -p 7860:7860 custom-f5-tts
+```
+
+The Gradio UI will be available at `http://localhost:7860/`.  The additional
+API routes can be accessed on the same host.

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,82 @@
+import gradio as gr
+from fastapi import FastAPI, UploadFile, File, Form
+from typing import List
+import torch
+
+# Global model holder
+model = None
+
+
+def load_model():
+    """Load the F5-TTS model into VRAM if it is not already loaded."""
+    global model
+    if model is None:
+        from f5_tts import F5TTS  # type: ignore
+        model = F5TTS()
+    return model
+
+
+def unload_model():
+    """Remove the model from VRAM without clearing caches."""
+    global model
+    model = None
+    torch.cuda.empty_cache()
+    return {"status": "unloaded"}
+
+
+def tts_single(text: str, reference: str):
+    """Generate a single speech sample using a reference voice."""
+    mdl = load_model()
+    output_path = "output.wav"
+    mdl.tts_to_file(text, reference, output_path)  # type: ignore[attr-defined]
+    return output_path
+
+
+async def several_tts(texts: List[str], reference_file: UploadFile):
+    """Generate several speech samples with a single reference voice."""
+    mdl = load_model()
+    data = await reference_file.read()
+    outputs: List[str] = []
+    for idx, text in enumerate(texts):
+        path = f"output_{idx}.wav"
+        mdl.tts_bytes_to_file(text, data, path)  # type: ignore[attr-defined]
+        outputs.append(path)
+    return {"files": outputs}
+
+
+fastapi_app = FastAPI()
+
+
+@fastapi_app.post("/load")
+def api_load():
+    load_model()
+    return {"status": "loaded"}
+
+
+@fastapi_app.post("/unload")
+def api_unload():
+    return unload_model()
+
+
+@fastapi_app.post("/several")
+async def api_several(
+    texts: str = Form(..., description="New line separated phrases"),
+    reference: UploadFile = File(...)
+):
+    text_list = [t.strip() for t in texts.splitlines() if t.strip()]
+    return await several_tts(text_list, reference)
+
+
+gradio_interface = gr.Interface(
+    fn=tts_single,
+    inputs=[gr.Textbox(label="Text"), gr.Audio(type="filepath", label="Reference Voice")],
+    outputs=gr.Audio(label="Generated Speech"),
+    allow_flagging="never",
+)
+
+app = gr.mount_gradio_app(fastapi_app, gradio_interface, path="/")
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=7860)


### PR DESCRIPTION
## Summary
- Run F5-TTS Gradio server with FastAPI extension for `/load`, `/unload`, and `/several` endpoints
- Provide Dockerfile based on F5-TTS image
- Document usage and Docker build instructions

## Testing
- `python -m py_compile __main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a63b7b695883289af7724c8063679d