### PR TITLE
Expose new model control endpoints in Gradio UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This project provides a Dockerised Gradio application for the F5-TTS voice
 cloning model.  It extends the standard Gradio server with additional API
 endpoints to control model loading and unloading and to generate multiple
-clips from a single reference voice.
+clips from a single reference voice.  The web UI exposes buttons for loading
+and unloading the model as well as a tab for generating several clips in one
+go.
 
 ## Features
 

--- a/__main__.py
+++ b/__main__.py
@@ -67,12 +67,56 @@ async def api_several(
     return await several_tts(text_list, reference)
 
 
-gradio_interface = gr.Interface(
-    fn=tts_single,
-    inputs=[gr.Textbox(label="Text"), gr.Audio(type="filepath", label="Reference Voice")],
-    outputs=gr.Audio(label="Generated Speech"),
-    allow_flagging="never",
-)
+def gr_load() -> str:
+    """Button helper to load the model."""
+    return api_load()["status"]
+
+
+def gr_unload() -> str:
+    """Button helper to unload the model."""
+    return api_unload()["status"]
+
+
+def gr_several(texts: str, reference: str) -> List[str]:
+    """Generate several clips from the GUI."""
+    text_list = [t.strip() for t in texts.splitlines() if t.strip()]
+    mdl = load_model()
+    with open(reference, "rb") as ref_file:
+        data = ref_file.read()
+    outputs: List[str] = []
+    for idx, text in enumerate(text_list):
+        path = f"output_{idx}.wav"
+        mdl.tts_bytes_to_file(text, data, path)  # type: ignore[attr-defined]
+        outputs.append(path)
+    return outputs
+
+
+with gr.Blocks() as gradio_interface:
+    with gr.Tab("Single"):
+        text_input = gr.Textbox(label="Text")
+        ref_audio = gr.Audio(type="filepath", label="Reference Voice")
+        generate_btn = gr.Button("Generate")
+        single_output = gr.Audio(label="Generated Speech")
+        generate_btn.click(tts_single, [text_input, ref_audio], single_output)
+
+    with gr.Tab("Several"):
+        texts_input = gr.Textbox(
+            label="Texts",
+            lines=5,
+            placeholder="One phrase per line",
+        )
+        ref_audio_multi = gr.Audio(type="filepath", label="Reference Voice")
+        several_btn = gr.Button("Generate Clips")
+        several_output = gr.Files(label="Generated Files")
+        several_btn.click(gr_several, [texts_input, ref_audio_multi], several_output)
+
+    with gr.Row():
+        load_button = gr.Button("Load Model")
+        unload_button = gr.Button("Unload Model")
+        status_box = gr.Textbox(label="Status")
+        load_button.click(gr_load, outputs=status_box)
+        unload_button.click(gr_unload, outputs=status_box)
+
 
 app = gr.mount_gradio_app(fastapi_app, gradio_interface, path="/")
 


### PR DESCRIPTION
## Summary
- Switch to a Blocks-based UI with tabs for single and batch TTS
- Add Load/Unload buttons and several-phrases generation support
- Update README to mention new interface features

## Testing
- `python -m py_compile __main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a63d77c0688328a9ec44a3b8882e3d