### PR TITLE
Fix Docker entrypoint module name error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ COPY . /app
 RUN pip install --no-cache-dir gradio fastapi uvicorn
 
 EXPOSE 7860
-CMD ["python", "-m", "custom-gradio-f5-tts"]
+# Run the main script directly. Using ``python -m`` with the repository name
+# fails because hyphens are not valid in Python module names.
+CMD ["python", "__main__.py"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go.
 ## Running locally
 
 ```bash
-python -m custom-gradio-f5-tts
+python __main__.py
 ```
 
 ## Docker


### PR DESCRIPTION
## Summary
- run the app's main module directly to avoid ModuleNotFoundError from hyphenated package name
- document local run instructions using `python __main__.py`

## Testing
- `python -m py_compile __main__.py && echo success`


------
https://chatgpt.com/codex/tasks/task_e_68a646277e988328adf40be6224ff664